### PR TITLE
optimize error call stack concatenations

### DIFF
--- a/src/jserror.c
+++ b/src/jserror.c
@@ -8,6 +8,7 @@
 static int jsB_stacktrace(js_State *J, int skip)
 {
 	char buf[256];
+	js_StringBuffer *sb = NULL;
 	int n = J->tracetop - skip;
 	if (n <= 0)
 		return 0;
@@ -22,10 +23,14 @@ static int jsB_stacktrace(js_State *J, int skip)
 				snprintf(buf, sizeof buf, "\n\tat %s:%d", S_EITHER_STR(file, "??"), line);
 		} else
 			snprintf(buf, sizeof buf, "\n\tat %s (%s)", S_EITHER_STR(name, "??"), S_EITHER_STR(file, "??"));
-		js_pushstring(J, buf);
-		if (n < J->tracetop - skip)
-			js_concat(J);
+		js_puts(J, &sb, buf);
 	}
+	if (sb) {
+		js_pushlstring(J, sb->s, sb->n);
+		js_free(J, sb);
+	}
+	else 
+		js_pushconst(J, "");
 	return 1;
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -245,13 +245,6 @@ static const char *require_js =
 	"}\n"
 	"require.cache = Object.create(null);\n"
 ;
-
-static const char *stacktrace_js =
-	"Error.prototype.toString = function() {\n"
-	"if (this.stackTrace) return this.name + ': ' + this.message + this.stackTrace;\n"
-	"return this.name + ': ' + this.message;\n"
-	"};\n"
-;
 #endif
 
 static int eval_print(js_State *J, const char *source)
@@ -371,7 +364,6 @@ int main(int argc, char **argv)
 	js_setglobal(J, "quit");
 #ifndef JS_COMPILER_DISABLED
 	js_dostring(J, require_js);
-	js_dostring(J, stacktrace_js);
 #endif
 	if (xoptind == argc) {
 		interactive = 1;


### PR DESCRIPTION
* avoid doing excessive mem string allocations
* remove unused `Error.ptototype.toString` snippet