### PR TITLE
avoid interning mem strings upon object creation

### DIFF
--- a/src/jsi.h
+++ b/src/jsi.h
@@ -84,16 +84,18 @@ const char *js_intern(js_State *J, const char *s);
 void jsS_dumpstrings(js_State *J);
 void jsS_freestrings(js_State *J);
 
-
 struct js_StringNode
 {
 	js_StringNode *left, *right;
-	int level;
+	int level; // reused as ref count for mem strings
 	unsigned int length;
 	unsigned int size;
-	int isunicode;
+	char isunicode;
+	char isattached; // mem string is attached to object
+	char gcmark;
 	char string[1];
 };
+
 extern js_StringNode jsS_sentinel;
 
 /* parser interned string literals */

--- a/src/jsintern.c
+++ b/src/jsintern.c
@@ -3,7 +3,7 @@
 
 /* Use an AA-tree to quickly look up interned strings. */
 
-js_StringNode jsS_sentinel = { &jsS_sentinel, &jsS_sentinel, 0, 0, 0, 0, ""};
+js_StringNode jsS_sentinel = { &jsS_sentinel, &jsS_sentinel, 0, 0, 0, 0, 0, 0, ""};
 
 static js_StringNode *jsS_newstringnode(js_State *J, const char *string, const char **result)
 {
@@ -14,6 +14,7 @@ static js_StringNode *jsS_newstringnode(js_State *J, const char *string, const c
 	node->level = 1;
 	node->size = n;
 	node->length = len;
+	node->isattached = 0;
 	node->isunicode = n != len;
 	memcpy(node->string, string, n + 1);
 	return *result = node->string, node;

--- a/src/jsrun.c
+++ b/src/jsrun.c
@@ -70,6 +70,8 @@ js_StringNode *jsV_newmemstring(js_State *J, const char *s, int n)
 	v->size = n;
 	v->length = n;
 	v->isunicode = 0;
+	v->gcmark = 0;
+	v->isattached = 0;
 	J->gcstr = v;
 	++J->gccounter;
 	return v;

--- a/src/jsvalue.c
+++ b/src/jsvalue.c
@@ -362,14 +362,21 @@ static js_Object *jsV_newstringfrom(js_State *J, js_Value *v)
 			obj->u.string.u.ptr8 = js_intern(J, v->u.string.u.shrstr);
 			obj->u.string.isunicode = 0;
 			break;
-		// already interned string
 		case JS_TLITSTR:
+			// already interned string, just set up referernce
 			obj->u.string.u.ptr8 = v->u.string.u.ptr8;
 			obj->u.string.isunicode = v->u.string.isunicode;
 			break;
 		case JS_TCONSTSTR:
-		case JS_TMEMSTR:
 			strnode = jsU_ptrtostrnode(js_intern(J, v->u.string.u.ptr8));
+			obj->u.string.u.ptr8 = strnode->string;
+			obj->u.string.isunicode = strnode->isunicode;
+			break;
+		case JS_TMEMSTR:
+			// attach mem string to object, to avoid interning
+			strnode = jsU_ptrtostrnode(v->u.string.u.ptr8);
+			strnode->isattached = 1;
+			strnode->level++;
 			obj->u.string.u.ptr8 = strnode->string;
 			obj->u.string.isunicode = strnode->isunicode;
 			break;


### PR DESCRIPTION
* mem strings are usually don't contain anything worth to be interned, so instead just reuse already allocated string memory, and keep counting to lock/unlock string garbage collection